### PR TITLE
# Zip形式の配布に対応

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,9 @@
-name: Publish
+name: Draft a new release
 
 on:
   push:
     branches:
-      - main
+      - develop
 
 jobs:
   build-win:
@@ -26,7 +26,7 @@ jobs:
       - name: Yarn install
         run: yarn
       - name: Build and Publish
-        run: yarn electron:build --publish always
+        run: yarn electron:build --publish onTagOrDraft
 
   build-macos:
     runs-on: macos-10.15
@@ -59,7 +59,7 @@ jobs:
       - name: Generate key chain
         run: xcrun altool --store-password-in-keychain-item "AC_PASSWORD" -u $APPLE_ID -p $APPLE_ID_PASS
       - name: Build and Publish
-        run: yarn electron:build --publish always
+        run: yarn electron:build --publish onTagOrDraft
 
   build-linux:
     runs-on: ubuntu-20.04
@@ -81,4 +81,4 @@ jobs:
       - name: Yarn install
         run: yarn
       - name: Build and Publish
-        run: yarn electron:build --publish always
+        run: yarn electron:build --publish onTagOrDraft

--- a/vue.config.js
+++ b/vue.config.js
@@ -10,7 +10,7 @@ module.exports = {
       mainProcessWatch: ['src/main/**/*'],
       nodeIntegration: true,
       builderOptions: {
-        appId: 'csv-plus',
+        appId: 'tech.plus-one.csv-plus',
         afterSign: 'scripts/notarize.js',
         productName: 'CSV+',
         extraResources: {
@@ -19,17 +19,20 @@ module.exports = {
           filter: '**/*.png',
         },
         win: {
-          target: ['msi', 'zip'],
-          fileAssociations: [
-            {
-              ext: ['csv'],
-              description: 'Comma separated values',
-            },
-            {
-              ext: ['tsv'],
-              description: 'Tab separated values',
-            },
-          ],
+          target: ['zip', 'nsis'],
+          fileAssociations: {
+            ext: ['csv', 'tsv'],
+          },
+        },
+        nsis: {
+          oneClick: false,
+          perMachine: true,
+          createDesktopShortcut: true,
+          runAfterFinish: true,
+          createStartMenuShortcut: true,
+          shortcutName: 'CSV+',
+          allowToChangeInstallationDirectory: true,
+          installerLanguages: ['ja_JP'],
         },
         mac: {
           category: 'public.app-category.developer-tools',


### PR DESCRIPTION
- msi形式の廃止
    - ファイルの関連付けやインストールディレクトリの選択に対応していないため
- exe形式の追加
- developにてタグを作成した時点で成果物のビルドを実行するように設定