### PR TITLE
# 改行コードが保存されない不具合の修正

### DIFF
--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -4,7 +4,7 @@ declare global {
   const __static: string
 }
 
-declare type Linefeed = 'CR' | 'CRLF' | 'LF'
+declare type Linefeed = 'CRLF' | 'LF'
 declare type SupportedEncoding =
   'UTF-8' |
   'UTF-16' |

--- a/src/main/model/CSVFile.ts
+++ b/src/main/model/CSVFile.ts
@@ -20,6 +20,14 @@ const defaultFileMeta = (): FileMeta => ({
   linefeed: defaultLinefeed(),
 })
 
+const linefeedChar = (linefeed: string) => {
+  switch (linefeed) {
+    case 'CRLF': return '\r\n'
+    case 'LF': return '\n'
+    default: return defaultLinefeed()
+  }
+}
+
 export default class CSVFile {
   readonly _ready?: Promise<boolean>
 
@@ -57,6 +65,7 @@ export default class CSVFile {
   }
 
   public save (path: string, data: string, options: FileMeta) {
+    data = data.replace('\n', linefeedChar(options.linefeed))
     fs.writeFile(path, iconv.encode(data, options.encoding), error => {
       if (error) throw error
     })

--- a/src/renderer/components/Footer/composables/useMenu.ts
+++ b/src/renderer/components/Footer/composables/useMenu.ts
@@ -32,7 +32,6 @@ export default (props: Props, context: SetupContext) => {
     linefeed: [
       { label: 'LF (MacOS/Linux)', value: 'LF' },
       { label: 'CRLF (Windows)', value: 'CRLF' },
-      { label: 'CR (旧MacOS)', value: 'CR' },
     ],
 
     encoding: [


### PR DESCRIPTION
- CRのみを上手く読み込めないため、選択肢から削除
    - 現代ではCRは利用されないようなので問題なしと判断