### PR TITLE
v0.9.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csv-plus",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "CSV+ is simplify cross-platform CSV tab editor.",
   "author": "Masaki Enomoto <m_enomoto@plus-one.tech>",
   "license": "MIT",

--- a/src/common/files.ts
+++ b/src/common/files.ts
@@ -4,3 +4,8 @@ export const FILE_FILTERS = [
   { name: 'CSV(*.csv, *.tsv)', extensions: ['csv', 'tsv'] },
   { name: '全てのファイル(*)', extensions: ['*'] },
 ]
+export const FILE_FILTERS_TSV = [
+  { name: 'TSV(*.tsv)', extensions: ['tsv'] },
+  { name: 'CSV(*.csv)', extensions: ['csv'] },
+  { name: '全てのファイル(*)', extensions: ['*'] },
+]

--- a/src/renderer/components/Grids/composables/gridHooks.ts
+++ b/src/renderer/components/Grids/composables/gridHooks.ts
@@ -23,6 +23,7 @@ export default (props: { tab: Tab }, context: SetupContext) => ({
       props.tab.table.undoRedo!.add({
         operation: operations.EDIT,
         details: details!.map(detail => ({
+          hasHeader: props.tab.table.options.hasHeader,
           row: detail[0],
           col: detail[1] as number,
           before: detail[2] ?? '',
@@ -81,6 +82,7 @@ export default (props: { tab: Tab }, context: SetupContext) => ({
       // 操作履歴の追加
       const emptyCols = () => new Array(amount).fill('')
       const details = [{
+        hasHeader: props.tab.table.options.hasHeader,
         col,
         amount,
         before: emptyCols(),
@@ -99,6 +101,7 @@ export default (props: { tab: Tab }, context: SetupContext) => ({
 
     // 操作履歴の追加
     const details = [{
+      hasHeader: props.tab.table.options.hasHeader,
       col,
       amount,
       before: props.tab.file.data
@@ -122,6 +125,7 @@ export default (props: { tab: Tab }, context: SetupContext) => ({
 
     // 操作履歴の追加
     const details = [{
+      hasHeader: props.tab.table.options.hasHeader,
       row,
       amount,
       before: [new Array(props.tab.file.data[0].length).fill('')],
@@ -140,13 +144,14 @@ export default (props: { tab: Tab }, context: SetupContext) => ({
     // 操作履歴の追加
     const before = []
     for (let i = row; i < row + amount; i++) {
-      before.push(props.tab.file.data[i])
+      before.push(props.tab.file.data[i + Number(props.tab.table.options.hasHeader)])
     }
 
     props.tab.table.undoRedo!.beginTransaction()
     props.tab.table.undoRedo!.add({
       operation: operations.REMOVE_ROW,
       details: [{
+        hasHeader: props.tab.table.options.hasHeader,
         row,
         amount,
         before,
@@ -171,13 +176,14 @@ export default (props: { tab: Tab }, context: SetupContext) => ({
     // 区切り文字で分割してペーストする
     if (data[0].length === 1) {
       props.tab.table.undoRedo!.transaction(() => {
+        const hasHeader = props.tab.table.options.hasHeader
         const details: ChangeDetail[] = []
 
         // 行がはみ出る場合、事前に行を追加する
-        if (props.tab.file.data.length <= cells[0].startRow + data.length) {
+        if (props.tab.file.data.length <= cells[0].startRow + data.length + Number(hasHeader)) {
           const rowLength = props.tab.file.data.length - 1
           props.tab.table.instance!
-            .alter(operations.INSERT_ROW, rowLength, (cells[0].startRow + data.length) - rowLength)
+            .alter(operations.INSERT_ROW, rowLength, (cells[0].startRow + data.length + Number(hasHeader)) - rowLength)
         }
 
         cells.forEach((cell) => {
@@ -196,12 +202,13 @@ export default (props: { tab: Tab }, context: SetupContext) => ({
               if (!props.tab.file.data[row]) props.tab.file.data.push([])
 
               details.push({
+                hasHeader,
                 row,
                 col,
-                before: props.tab.file.data[row][col] ?? '',
+                before: props.tab.file.data[row + Number(hasHeader)][col] ?? '',
                 after: rowData[col - cell.startCol],
               })
-              props.tab.file.data[row][col] = rowData[col - cell.startCol]
+              props.tab.file.data[row + Number(hasHeader)][col] = rowData[col - cell.startCol]
             }
           }
 

--- a/src/renderer/components/Grids/composables/gridHooks.ts
+++ b/src/renderer/components/Grids/composables/gridHooks.ts
@@ -140,14 +140,20 @@ export default (props: { tab: Tab }, context: SetupContext) => ({
 
   beforeRemoveRow: (row: number, amount: number) => {
     props.tab.dirty = true
-
-    // 操作履歴の追加
-    const before = []
-    for (let i = row; i < row + amount; i++) {
-      before.push(props.tab.file.data[i + Number(props.tab.table.options.hasHeader)])
-    }
+    const headerNum = Number(props.tab.table.options.hasHeader)
+    const data = props.tab.file.data
 
     props.tab.table.undoRedo!.beginTransaction()
+
+    // 行がはみ出る場合、事前に行を追加する
+    const rowLength = data.length - 1
+    if (rowLength <= row + amount + headerNum) {
+      props.tab.table.instance!
+        .alter(operations.INSERT_ROW, rowLength, row + amount + headerNum - rowLength)
+    }
+
+    // 操作履歴の追加
+    const before = data.slice(row + headerNum, row + headerNum + amount)
     props.tab.table.undoRedo!.add({
       operation: operations.REMOVE_ROW,
       details: [{

--- a/src/renderer/components/Grids/composables/useGrid.ts
+++ b/src/renderer/components/Grids/composables/useGrid.ts
@@ -23,9 +23,11 @@ const sanitizeOption: SanitizeOption = {
 export default (props: { tab: Tab }, context: SetupContext) => {
   const wrapper = ref<HTMLDivElement>()
   const settings = computed((): HandsOnTable.GridSettings => ({
-    data: props.tab.table.options.hasHeader ? props.tab.file.data.slice(1) : props.tab.file.data,
+    data: props.tab.file.data,
     autoColumnSize: { syncLimit: 10 },
     autoRowSize: false,
+    autoWrapCol: false,
+    autoWrapRow: false,
     colHeaders: props.tab.table.options.hasHeader
       ? props.tab.file.data[0].map((d: string) => d ? sanitize(d, sanitizeOption) : '') as string[]
       : true,

--- a/src/renderer/pages/composables/registerShortcuts.ts
+++ b/src/renderer/pages/composables/registerShortcuts.ts
@@ -34,39 +34,53 @@ const getEdgeCell = (tab: Tab, direction: Direction, currentCell?: HandsOnTable.
   currentCell = currentCell || tab.table.instance?.getSelectedRange()?.shift()
   if (!currentCell) return 0
 
-  const data = tab.file.data
+  const data = tab.table.options.hasHeader ? tab.file.data.slice(1) : tab.file.data
   switch (direction) {
     case 'up': {
       const currentRow = Math.min(currentCell.from.row, currentCell.to.row)
-      const target = !data[Math.max(currentRow - 1, 0)][currentCell.from.col]
+
+      // 1つ上のセルが空白かどうか
+      const cellState = !data[Math.max(currentRow - 1, 0)][currentCell.from.col]
+
       for (let row = Math.max(currentRow - 2, 0); row >= 0; row--) {
-        if (!!data[row][currentCell.from.col] === target) return target ? row : row + 1
+        if (!!data[row][currentCell.from.col] === cellState) return cellState ? row : row + 1
       }
       return 0
     }
     case 'down': {
-      const length = data.length - Number(tab.table.options.hasHeader) - 2
+      const length = data.length - 2
       const currentRow = Math.max(currentCell.from.row, currentCell.to.row)
-      const target = !data[Math.min(currentRow + 1, length)][currentCell.from.col]
+      if (length <= currentRow) return length + 1
+
+      // 1つ下のセルが空白かどうか
+      const cellState = !data[Math.min(currentRow + 1, length)][currentCell.from.col]
+
       for (let row = Math.min(currentRow + 2, length); row < length; row++) {
-        if (!!data[row][currentCell.from.col] === target) return target ? row : row - 1
+        if (!!data[row][currentCell.from.col] === cellState) return cellState ? row : row - 1
       }
       return length
     }
     case 'left': {
       const currentCol = Math.min(currentCell.from.col, currentCell.to.col)
-      const target = !data[Math.max(currentCell.from.row, 0)][currentCol - 1]
+
+      // 1つ左のセルが空白かどうか
+      const cellState = !data[Math.max(currentCell.from.row, 0)][currentCol - 1]
+
       for (let col = Math.max(currentCol - 2, 0); col >= 0; col--) {
-        if (!!data[currentCell.from.row][col] === target) return target ? col : col + 1
+        if (!!data[currentCell.from.row][col] === cellState) return cellState ? col : col + 1
       }
       return 0
     }
     case 'right': {
       const length = data[currentCell.from.row].length - 2
       const currentCol = Math.max(currentCell.from.col, currentCell.to.col)
-      const target = !data[currentCell.from.row][Math.min(currentCol + 1, length)]
+      if (length <= currentCol) return length + 1
+
+      // 1つ右のセルが空白かどうか
+      const cellState = !data[currentCell.from.row][Math.min(currentCol + 1, length)]
+
       for (let col = Math.min(currentCol + 2, length); col < length; col++) {
-        if (!!data[currentCell.from.row][col] === target) return target ? col : col - 1
+        if (!!data[currentCell.from.row][col] === cellState) return cellState ? col : col - 1
       }
       return length
     }

--- a/src/renderer/pages/composables/registerShortcuts.ts
+++ b/src/renderer/pages/composables/registerShortcuts.ts
@@ -34,7 +34,7 @@ const getEdgeCell = (tab: Tab, direction: Direction, currentCell?: HandsOnTable.
   currentCell = currentCell || tab.table.instance?.getSelectedRange()?.shift()
   if (!currentCell) return 0
 
-  const data = tab.table.options.hasHeader ? tab.file.data.slice(1) : tab.file.data
+  const data = tab.file.data
   switch (direction) {
     case 'up': {
       const currentRow = Math.min(currentCell.from.row, currentCell.to.row)
@@ -45,7 +45,7 @@ const getEdgeCell = (tab: Tab, direction: Direction, currentCell?: HandsOnTable.
       return 0
     }
     case 'down': {
-      const length = data.length - 1
+      const length = data.length - Number(tab.table.options.hasHeader) - 2
       const currentRow = Math.max(currentCell.from.row, currentCell.to.row)
       const target = !data[Math.min(currentRow + 1, length)][currentCell.from.col]
       for (let row = Math.min(currentRow + 2, length); row < length; row++) {
@@ -62,7 +62,7 @@ const getEdgeCell = (tab: Tab, direction: Direction, currentCell?: HandsOnTable.
       return 0
     }
     case 'right': {
-      const length = data[currentCell.from.row].length - 1
+      const length = data[currentCell.from.row].length - 2
       const currentCol = Math.max(currentCell.from.col, currentCell.to.col)
       const target = !data[currentCell.from.row][Math.min(currentCol + 1, length)]
       for (let col = Math.min(currentCol + 2, length); col < length; col++) {

--- a/src/renderer/plugins/UndoRedo.ts
+++ b/src/renderer/plugins/UndoRedo.ts
@@ -185,7 +185,6 @@ export default class UndoRedo {
 
   public undo () {
     if (this._pointer <= this._histories[0].id) return
-    console.log('undo', this._histories)
 
     this._pointer--
     let lastDetails: ChangeDetail|undefined

--- a/src/renderer/plugins/UndoRedo.ts
+++ b/src/renderer/plugins/UndoRedo.ts
@@ -3,7 +3,6 @@ import * as operations from '@/common/operations'
 import History from '@/main/models/History'
 
 interface Cell {
-  hasHeader: boolean
   row?: number
   col?: number
   amount?: number
@@ -43,11 +42,11 @@ export default class UndoRedo {
    */
   private _editCell (cell: Cell, data: string|string[]) {
     if (typeof cell.row === 'number' && typeof cell.col === 'number' && typeof data === 'string') {
-      this.data[cell.row + Number(cell.hasHeader)][cell.col] = data
+      this.data[cell.row][cell.col] = data
     } else if (typeof cell.row === 'number' && typeof data !== 'string') {
-      this.data[cell.row + Number(cell.hasHeader)] = data
+      this.data[cell.row] = data
     } else if (typeof cell.col === 'number' && typeof data === 'string') {
-      for (let i = Number(cell.hasHeader); i < this.data.length; i++) {
+      for (let i = 0; i < this.data.length; i++) {
         this.data[i][cell.col] = data
       }
     }
@@ -61,10 +60,10 @@ export default class UndoRedo {
   private _spliceRow (cell: Cell, data: number|string[][]): void {
     if (typeof data === 'number') {
       // remove row
-      this.data.splice(cell.row! + Number(cell.hasHeader), data)
+      this.data.splice(cell.row!, data)
     } else {
       // insert row
-      this.data.splice(cell.row! + Number(cell.hasHeader), 0, ...data)
+      this.data.splice(cell.row!, 0, ...data)
     }
   }
 
@@ -76,12 +75,12 @@ export default class UndoRedo {
   private _spliceCol (cell: Cell, data: number|string[][]) {
     if (typeof data === 'number') {
       // remove col
-      for (let i = Number(cell.hasHeader); i < this.data.length; i++) {
+      for (let i = 0; i < this.data.length; i++) {
         this.data[i].splice(cell.col!, data)
       }
     } else {
       // insert col
-      for (let i = Number(cell.hasHeader); i < this.data.length; i++) {
+      for (let i = 0; i < this.data.length; i++) {
         this.data[i].splice(cell.col!, 0, ...data[i])
       }
     }
@@ -95,12 +94,10 @@ export default class UndoRedo {
    */
   private _jumpToCell (detail: ChangeDetail) {
     if (typeof detail.row === 'number') {
-      const currentHeader = Number(this.table.options.hasHeader)
-      const hasHeader = Number(detail.hasHeader)
       this.table.instance!.selectCell(
-        detail.row - currentHeader + hasHeader,
+        detail.row,
         detail.col || 0,
-        detail.row - currentHeader + hasHeader,
+        detail.row,
         detail.col || 0,
         true,
       )


### PR DESCRIPTION
## 「一行目をヘッダーに設定する」利用時の不具合修正

- 最後尾の空白行でCtrl+矢印が効かなくなる不具合を修正
- 最後尾の空白行でコピー・ペーストの挙動がおかしくなる不具合を修正
- 行削除でエラーが生じることがある問題を修正 

## 動作変更
- Ctrl+矢印キーで最後の空白行まで進まないように変更
- セル移動時、端のセルから逆端のセルへループしないように変更
- 区切り文字が「タブ区切り」の場合、tsvとして保存するよう変更
  - 名前を付けて保存の場合のみ有効
  - 上書き保存の場合は影響なし
