### PR TITLE
Feature/#114

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,2 +1,3 @@
 import './menu/index'
+import './system/initializeApp'
 import './system/bootstrap'

--- a/src/main/menu/templates/FileMenu.ts
+++ b/src/main/menu/templates/FileMenu.ts
@@ -11,7 +11,7 @@ const recentDocumentsMenu: MenuItemConstructorOptions = {
 
 const getRecentDocuments = () => {
   const menu = new Menu()
-  History.getRecentDocuments().forEach(menuItem => menu.append(menuItem))
+  History.recentDocuments.forEach(menuItem => menu.append(menuItem))
   menu.append(new MenuItem({
     label: '履歴を消去',
     click: FileMenuController.clearRecent,

--- a/src/main/models/CSVFile.ts
+++ b/src/main/models/CSVFile.ts
@@ -119,7 +119,7 @@ export default class CSVFile {
         next()
       },
       final (next: Stream.TransformCallback) {
-        this.push(iconv.decode(buffer, meta.encoding))
+        if (buffer.length) this.push(iconv.decode(buffer, meta.encoding))
         next()
       },
     })

--- a/src/main/models/History.ts
+++ b/src/main/models/History.ts
@@ -3,6 +3,7 @@ import * as pathModule from 'path'
 import { app, MenuItem } from 'electron'
 import { menu } from '@/main/menu'
 import FileMenuController from '@/main/menu/controllers/FileMenuController'
+import path from 'path'
 
 interface RecentDocument {
   path: string
@@ -14,17 +15,25 @@ const MAX_HISTORY_LENGTH = 10
 const isMac = process.platform === 'darwin'
 
 class History {
+  private _recentDirectory: string = app.getPath('documents')
   private _recentDocuments: RecentDocument[] = []
+  private _tabHistory: string[] = []
 
   public constructor () {
     if (isMac) return
 
-    try {
-      const data = fs.readFileSync(pathModule.join(app.getPath('appData'), 'recentDocuments.json'))
-      this._recentDocuments = JSON.parse(data.toString()) as RecentDocument[]
-    } catch (e) {
-      this._recentDocuments = []
-    }
+    this._loadPersistentHistory('recent-directory').then(data => { this._recentDirectory = data })
+    this._loadPersistentHistory('recent-documents.json').then(data => { this._recentDocuments = JSON.parse(data) })
+    this._loadPersistentHistory('tab-history.json').then(data => { this._tabHistory = JSON.parse(data) })
+  }
+
+  public get recentDirectory (): string {
+    return this._recentDirectory
+  }
+
+  public set recentDirectory (path: string) {
+    this._recentDirectory = path
+    this.persistentHistory('recent-directory', path)
   }
 
   /**
@@ -32,7 +41,7 @@ class History {
    *
    * @return {MenuItem[]}
    */
-  public getRecentDocuments (): MenuItem[] {
+  public get recentDocuments (): MenuItem[] {
     return this._recentDocuments
       .sort((a, b) => b.timestamp - a.timestamp)
       .slice(0, 10)
@@ -40,6 +49,10 @@ class History {
         label: doc.path,
         click: FileMenuController.openRecent,
       }))
+  }
+
+  public get tabHistory (): string[] {
+    return this._tabHistory
   }
 
   /**
@@ -59,7 +72,7 @@ class History {
     this._recentDocuments.sort((a, b) => b.timestamp - a.timestamp).slice(0, 10)
     this.persistentRecentDocuments()
 
-    // メニュー項目の追加
+    // メニュー項目への追加
     const menuItem = menu.getMenuItemById('recentDocuments')
     if (!menuItem || !menuItem.submenu) return
 
@@ -77,16 +90,17 @@ class History {
     })
   }
 
-  /**
-   * [最近開いたファイル]データの永続化
-   */
   public persistentRecentDocuments () {
-    fs.writeFileSync(
-      pathModule.join(app.getPath('appData'), 'recentDocuments.json'),
-      JSON.stringify(this._recentDocuments),
-    )
+    this.persistentHistory('recent-documents.json', JSON.stringify(this._recentDocuments))
   }
 
+  public persistentTabHistory (paths: string) {
+    this.persistentHistory('tab-history.json', paths)
+  }
+
+  /**
+   * [最近開いたファイル]の履歴削除
+   */
   public clearRecentDocuments (): void {
     this._recentDocuments = []
     this.persistentRecentDocuments()
@@ -96,6 +110,25 @@ class History {
       .forEach((item, index, items) => {
         if (index !== (items.length - 1)) item.visible = false
       })
+  }
+
+  private _loadPersistentHistory (filename: string): Promise<string> {
+    return new Promise(resolve => {
+      fs.readFile(
+        path.join(app.getPath('userData'), 'history', filename),
+        { encoding: 'utf8' },
+        (err, data) => resolve((err || !data) ? '' : data.toString()))
+    })
+  }
+
+  /**
+   * 履歴データの永続化
+   */
+  public persistentHistory (filename: string, data: string) {
+    fs.writeFileSync(
+      pathModule.join(app.getPath('userData'), 'history', filename),
+      data,
+    )
   }
 }
 

--- a/src/main/system/bootstrap.ts
+++ b/src/main/system/bootstrap.ts
@@ -1,4 +1,3 @@
-import * as fs from 'fs'
 import * as path from 'path'
 import { app, protocol, BrowserWindow } from 'electron'
 import { createProtocol } from 'vue-cli-plugin-electron-builder/lib'
@@ -58,13 +57,9 @@ async function createWindow () {
   // File load from arguments
   window.webContents.on('did-finish-load', async () => {
     csvFile.setWindow(window)
-    let paths: string[] = []
 
     // 前回開いていたタブの復元
-    try {
-      const tabHistory = fs.readFileSync(path.join(app.getPath('userData'), 'tab_history.json'))
-      paths = paths.concat(JSON.parse(tabHistory.toString()) as string[])
-    } catch (e) {}
+    const paths: string[] = History.tabHistory
 
     // ファイルを開こうとしている場合読み込み
     const argv = process.argv

--- a/src/main/system/initializeApp.ts
+++ b/src/main/system/initializeApp.ts
@@ -1,0 +1,30 @@
+import * as fs from 'fs'
+import * as pathModule from 'path'
+import { app } from 'electron'
+
+// 履歴ディレクトリの作成
+const historyDir = pathModule.join(app.getPath('userData'), 'history')
+if (!fs.existsSync(historyDir)) {
+  fs.mkdirSync(historyDir)
+}
+
+// TODO: 移行期間対応を過ぎたら削除
+// root直下の履歴ファイルがあれば移動
+const oldRecentDocuments = pathModule.join(app.getPath('appData'), 'recentDocuments.json')
+const newRecentDocuments = pathModule.join(historyDir, 'recent-documents.json')
+if (fs.existsSync(oldRecentDocuments)) {
+  if (fs.existsSync(newRecentDocuments)) {
+    fs.rmSync(oldRecentDocuments)
+  } else {
+    fs.renameSync(oldRecentDocuments, newRecentDocuments)
+  }
+}
+const oldTabHistory = pathModule.join(app.getPath('userData'), 'tab_history.json')
+const newTabHistory = pathModule.join(historyDir, 'tab-history.json')
+if (fs.existsSync(oldTabHistory)) {
+  if (fs.existsSync(newTabHistory)) {
+    fs.rmSync(oldTabHistory)
+  } else {
+    fs.renameSync(oldTabHistory, newTabHistory)
+  }
+}

--- a/src/main/system/ipcEvents.ts
+++ b/src/main/system/ipcEvents.ts
@@ -1,5 +1,4 @@
 import * as fs from 'fs'
-import * as path from 'path'
 import csvParse from 'csv-parse'
 import { parse } from 'csv-parse/lib/sync'
 import csvStringify from 'csv-stringify'
@@ -16,6 +15,7 @@ import {
 import { FileMeta } from '@/@types/types'
 import * as channels from '@/common/channels'
 import FileMenuController from '@/main/menu/controllers/FileMenuController'
+import History from '@/main/models/History'
 import CSVFile from '@/main/models/CSVFile'
 
 const csvFile = new CSVFile()
@@ -127,8 +127,6 @@ ipcMain.handle(channels.FILE_DESTROY_CONFIRM, (e: IpcMainInvokeEvent, file: chan
   return selected === BUTTON_NO_SAVE
 })
 
-ipcMain.on(channels.TABS_SAVE, (e: IpcMainEvent, paths: channels.TABS_SAVE) => {
-  fs.writeFileSync(path.join(app.getPath('userData'), 'tab_history.json'), paths)
-})
+ipcMain.on(channels.TABS_SAVE, (e: IpcMainEvent, paths: channels.TABS_SAVE) => History.persistentTabHistory(paths))
 
 ipcMain.on(channels.APP_CLOSE, () => app.exit())


### PR DESCRIPTION
[# 0バイトのファイルを開けない](https://github.com/plusone-masaki/csv-plus/commit/a77f0643f8c0a2cfc69039657b052c4fbe5d1d0d) 

- バッファが空の場合、ストリーム内のデータ送信処理をスキップする

[# 履歴機能の強化](https://github.com/plusone-masaki/csv-plus/commit/096e6215e280d49dbececc45ddd87368d3dad967) 

- 「ファイルを開く」操作時、最後に開いたフォルダを初期表示するようにしました
- 「名前を付けて保存」操作時、対象ファイルのあるフォルダまたは最後に開いたフォルダを初期表示するようにしました

## リファクタリング
- 内部で使用する履歴ファイルの保存先を構造化